### PR TITLE
Add links to Newspaper Articles

### DIFF
--- a/CorpusSearch.Test/QueryBase.cs
+++ b/CorpusSearch.Test/QueryBase.cs
@@ -59,6 +59,11 @@ namespace CorpusSearch.Test
             public string Notes => null;
 
             public string Source => null;
+
+            public object GetExtensionData(string key)
+            {
+                return null;
+            }
         }
     }
 }

--- a/CorpusSearch/ClientApp/src/components/FetchDataDocument.js
+++ b/CorpusSearch/ClientApp/src/components/FetchDataDocument.js
@@ -37,7 +37,7 @@ export class FetchDataDocument extends Component {
 
                 { response.notes && <><br /><br />{response.notes}</>}
 
-                { response.source && <><br /><br />{response.source}</>} { response.sourceLinks && <>{response.sourceLinks.map(x => <a rel="noreferrer" href={x.url}>{x.text}</a>)}</>}
+                { response.source && <><br /><br />{response.source}</>} { response.sourceLinks && <>{response.sourceLinks.map(x => <>| <a rel="noreferrer" href={x.url}>{x.text}</a> </>)}</>}
             <table className='table table-striped' aria-labelledby="tabelLabel">
                 <thead>
                     <tr>

--- a/CorpusSearch/ClientApp/src/components/FetchDataDocument.js
+++ b/CorpusSearch/ClientApp/src/components/FetchDataDocument.js
@@ -37,7 +37,7 @@ export class FetchDataDocument extends Component {
 
                 { response.notes && <><br /><br />{response.notes}</>}
 
-                { response.source && <><br /><br />{response.source}</>}
+                { response.source && <><br /><br />{response.source}</>} { response.sourceLinks && <>{response.sourceLinks.map(x => <a rel="noreferrer" href={x.url}>{x.text}</a>)}</>}
             <table className='table table-striped' aria-labelledby="tabelLabel">
                 <thead>
                     <tr>

--- a/CorpusSearch/Controllers/IMuseumNewspaperController.cs
+++ b/CorpusSearch/Controllers/IMuseumNewspaperController.cs
@@ -23,5 +23,30 @@ namespace CorpusSearch.Controllers
                 return base.BadRequest(e.Message);
             }
         }
+
+        /// <summary>Redirects to a page where a user can view a full component (one or more pieces of Manx)</summary>
+        /// <remarks>A Component and a chunk id are typically the same, but some chunks aren't components</remarks>
+        /// <remarks>sample call: /IMuseumNewspaper/Component/V1?newspaper=MNH&date=1845-01-08&id=Ar00318</remarks>
+        [HttpGet("Component/V1")]
+        public IActionResult Component([FromQuery] string newspaper, [FromQuery] string date, [FromQuery] string id)
+        {
+            try
+            {
+                NewspaperComponent reference = NewspaperComponent.FromOrThrow(newspaper, date, id);
+                string href = reference.Href;
+                string componentId = reference.ComponentId;
+
+                // A ts parameter was provided (the timestamp that the item was modified. YYYYMMDDHHMMSS)
+                // this does not seem to be necessary in some cases, but not others.
+                // Sometimes a bad TS value (or no TS value) causes the images to fail to load with a 403 forbidden
+                string ts = "20210606011511"; 
+
+                return base.Redirect($"https://www.imuseum.im/Olive/APA/IsleofMan/get/article.ashx?href={href}&id={componentId}&mode=image&ts={ts}");
+            }
+            catch (Exception e)
+            {
+                return base.BadRequest(e.Message);
+            }
+        }
     }
 }

--- a/CorpusSearch/Controllers/IMuseumNewspaperController.cs
+++ b/CorpusSearch/Controllers/IMuseumNewspaperController.cs
@@ -8,6 +8,7 @@ namespace CorpusSearch.Controllers
     public class IMuseumNewspaperController : Controller
     {
         [HttpGet("Image/V1")]
+        [HttpGet("Chunk/V1")]
         public IActionResult Image([FromQuery] string newspaper, [FromQuery] string date, [FromQuery] string id)
         {
             try

--- a/CorpusSearch/Controllers/SearchController.cs
+++ b/CorpusSearch/Controllers/SearchController.cs
@@ -84,6 +84,7 @@ namespace CorpusSearch.Controllers
             public string GitHubLink { get; set; }
             public object Notes { get; internal set; }
             public string Source { get; set; }
+            public List<SourceLink> SourceLinks { get; internal set; } = new List<SourceLink>();
 
             internal static SearchWorkResult Empty(string title)
             {

--- a/CorpusSearch/Model/Document.cs
+++ b/CorpusSearch/Model/Document.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using CorpusSearch.Dependencies.CsvHelper;
+using Newtonsoft.Json;
 
 namespace CorpusSearch.Model
 {
@@ -34,6 +35,14 @@ namespace CorpusSearch.Model
         public string Notes { get; set; }
 
         public string Source { get; set; }
+
+        [JsonExtensionData]
+        public IDictionary<string, object> ExtensionData { get; set; } = new Dictionary<string, object>();
+
+        public object GetExtensionData(string key)
+        {
+            return ExtensionData[key];
+        }
 
         internal virtual List<DocumentLine> LoadLocalFile()
         {

--- a/CorpusSearch/Model/IDocument.cs
+++ b/CorpusSearch/Model/IDocument.cs
@@ -21,6 +21,8 @@ namespace CorpusSearch.Model
         public string RelativeCsvPath { get; }
         string Notes { get; }
         string Source { get; }
+
+        object GetExtensionData(string key);
     }
 
     public static class IDocumentExtensions

--- a/CorpusSearch/Model/SourceLink.cs
+++ b/CorpusSearch/Model/SourceLink.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CorpusSearch.Model
+{
+    /// <summary>A link to a source</summary>
+    public class SourceLink
+    {
+        public string Text { get; set; }
+        public string Url { get; set; }
+    }
+}

--- a/CorpusSearch/Service/DocumentSearchService2.cs
+++ b/CorpusSearch/Service/DocumentSearchService2.cs
@@ -11,11 +11,13 @@ namespace CorpusSearch.Service
     {
         private readonly WorkService workService;
         private readonly Searcher searcher;
+        private readonly WorkEnricher enricher;
 
-        public DocumentSearchService2(WorkService workService, Searcher searcher)
+        public DocumentSearchService2(WorkService workService, Searcher searcher, WorkEnricher enricher)
         {
             this.workService = workService;
             this.searcher = searcher;
+            this.enricher = enricher;
         }
 
         public async Task<SearchWorkResult> SearchWork(CorpusSearchWorkQuery workQuery)
@@ -35,6 +37,8 @@ namespace CorpusSearch.Service
             ret.Source = document.Source;
 
             var results = searcher.SearchWork(workQuery.Ident, workQuery.Query, ToSearchOptions(workQuery));
+
+            enricher.Enrich(ret, document);
 
             ret.EnrichResults(results.Lines);
             // Handles more than one result per document line

--- a/CorpusSearch/Service/IMuseumNewspaperService.cs
+++ b/CorpusSearch/Service/IMuseumNewspaperService.cs
@@ -39,6 +39,36 @@ namespace CorpusSearch.Service
             }
         }
 
+        /// <summary>A component consists of one or more chunks</summary>
+        /// <remarks>Typically what we're after whn viewing, this is one or more items of Manx text</remarks>
+        public class NewspaperComponent
+        {
+            public string ComponentId { get; set; }
+
+            public NewspaperReference Reference { get; set; }
+            public string Href => Reference.Href;
+
+            internal static NewspaperComponent FromOrThrow(string newspaper, string date, string componentId)
+            {
+                if (!NewspaperNameToId.ContainsValue(newspaper))
+                {
+                    throw new ArgumentException($"'{newspaper}' is not a valid newspaper reference. Example: 'MNH' refers to Mona's Herald");
+                }
+
+                DateTime d = DateTime.Parse(date);
+
+                return new NewspaperComponent()
+                {
+                    ComponentId = componentId,
+                    Reference = new NewspaperReference()
+                    {
+                        Date = d,
+                        NewspaperIdentifier = newspaper
+                    }
+                };
+            }
+        }
+
         /// <summary>A reference to an issue of a newspaper, with an optional page</summary>
         /// <remarks>It is not easy to obtain a browsable source from this style of reference</remarks>
         public class NewspaperReference
@@ -49,7 +79,7 @@ namespace CorpusSearch.Service
             public string NewspaperIdentifier { get; set; }
 
             public int? Page { get; set; }
-            public string Href => $"{NewspaperIdentifier}%2F{Date.Year}%2F{Date.Month}%2F{Date.Day}";
+            public string Href => $"{NewspaperIdentifier}%2F{Date.Year}%2F{Date.Month:D2}%2F{Date.Day:D2}";
         }
 
         // Obtained from https://www.imuseum.im/Olive/APA/IsleofMan/get.res?id=page.Scripts&kind=script&uq=20210325071104&for=%7E%2Fdefault.aspx&mode=group

--- a/CorpusSearch/Service/IMuseumNewspaperService.cs
+++ b/CorpusSearch/Service/IMuseumNewspaperService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MoreLinq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -50,22 +51,32 @@ namespace CorpusSearch.Service
 
             internal static NewspaperComponent FromOrThrow(string newspaper, string date, string componentId)
             {
+                DateTime d = DateTime.Parse(date);
+                return FromOrThrow(newspaper, d, componentId);
+            }
+
+            internal static NewspaperComponent FromOrThrow(string newspaper, DateTime date, string componentId)
+            {
                 if (!NewspaperNameToId.ContainsValue(newspaper))
                 {
                     throw new ArgumentException($"'{newspaper}' is not a valid newspaper reference. Example: 'MNH' refers to Mona's Herald");
                 }
 
-                DateTime d = DateTime.Parse(date);
 
                 return new NewspaperComponent()
                 {
                     ComponentId = componentId,
                     Reference = new NewspaperReference()
                     {
-                        Date = d,
+                        Date = date,
                         NewspaperIdentifier = newspaper
                     }
                 };
+            }
+
+            internal string ToLocalUrl()
+            {
+                return $"/IMuseumNewspaper/Component/V1?newspaper={Reference.NewspaperIdentifier}&date={Reference.Date:yyyy-MM-dd}&id={ComponentId}";
             }
         }
 
@@ -130,5 +141,16 @@ namespace CorpusSearch.Service
             ["Unter Uns"] = "UNU",
             ["Werden"] = "WER",
         };
+
+        internal static string ParseNewspaperId(string source)
+        {
+            string key = NewspaperNameToId.Select(x => (x.Key, source.IndexOf(x.Key)))
+                .Where(x => x.Item2 != -1)
+                .MinBy(x => x.Item2)
+                .Single()
+                .Key;
+
+            return NewspaperNameToId[key];
+        }
     }
 }

--- a/CorpusSearch/Service/WorkEnricher.cs
+++ b/CorpusSearch/Service/WorkEnricher.cs
@@ -1,0 +1,51 @@
+﻿using CorpusSearch.Controllers;
+using CorpusSearch.Model;
+using System;
+using static CorpusSearch.Service.IMuseumNewspaperService;
+
+namespace CorpusSearch.Service
+{
+    public class WorkEnricher
+    {
+        internal void Enrich(SearchController.SearchWorkResult result, IDocument document)
+        {
+            // currently only MNH newspaper sources, extract to a source enricher if we add more
+            try
+            {
+                if (document.GetExtensionData("mnhNewsComponent") == null)
+                {
+                    return;
+                }
+
+                string componentId = (string)document.GetExtensionData("mnhNewsComponent");
+                if (document.CreatedCircaEnd != document.CreatedCircaStart)
+                {
+                    return;
+                }
+                if (document.CreatedCircaStart == null)
+                {
+                    return;
+                }
+
+                DateTime date = document.CreatedCircaStart.Value;
+
+                string newspaperId = IMuseumNewspaperService.ParseNewspaperId(document.Source);
+
+                var component = NewspaperComponent.FromOrThrow(newspaperId, date, componentId);
+
+
+                SourceLink link = new SourceLink
+                {
+                    Text = "Article",
+                    Url = component.ToLocalUrl(),
+                };
+
+                result.SourceLinks.Add(link);
+
+            } catch
+            {
+
+            }
+        }
+    }
+}

--- a/CorpusSearch/Startup.cs
+++ b/CorpusSearch/Startup.cs
@@ -43,6 +43,7 @@ namespace CorpusSearch
             services.AddSingleton<ISearchDictionary>(provider => provider.GetService<CregeenDictionaryService>());
             services.AddSingleton<WorkService>();
             services.AddSingleton<DocumentSearchService2>();
+            services.AddSingleton<WorkEnricher>();
             services.AddSingleton<OverviewSearchService2>();
 
             // In production, the React files will be served from this directory


### PR DESCRIPTION
To allow this, `mnhNewsComponent` needs to be set to either an array, or a string containing the component Id from the iMuseum website.

This can be found by:

* find component using "browse", then double click, a box containing images should appear.
* Share via email
* Copy the URL
* Extract the ID

Example: `https://www.imuseum.im/Olive/APA/IsleofMan/SharedView.Article.aspx?href=MNH%2F1840%2F12%2F22&id=Ar00304&sk=2BD5DE88&viewMode=image`

-> `Ar00304`

----

This was flaky during testing (sometimes the URL produced a 403), incrementing the timestamp by 1 fixes this.